### PR TITLE
misc: Copy .lib file on Windows to target directory

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -15,6 +15,8 @@ dflags "-fvisibility=hidden" platform="ldc"
 dflags "-link-defaultlib-shared=false" platform="ldc"
 dflags "-d-version=GL_ARB" platform="ldc"
 
+copyFiles "*/inochi2d-c.lib" platform="windows-ldc" // On Windows, copy the lib file to allow usage of link.exe
+
 configuration "nogl" {
     subConfiguration "inochi2d" "renderless"
     versions "nogl"


### PR DESCRIPTION
This is required when linking with LINK.EXE on Windows with msvc.

Required for Rust target ``*-pc-windows-msvc``