### PR TITLE
Fix inochi2d.h not compiling using C/C++ compilers

### DIFF
--- a/inochi2d.h
+++ b/inochi2d.h
@@ -10,6 +10,10 @@
 #ifndef H_INOCHI2D
 #define H_INOCHI2D
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
     struct InError {
         size_t len;
         const char* msg;
@@ -56,6 +60,10 @@
         void inPuppetDraw(InPuppet* puppet);
     #endif
 
+
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif

--- a/inochi2d.h
+++ b/inochi2d.h
@@ -13,12 +13,13 @@
     struct InError {
         size_t len;
         const char* msg;
-    }
+    };
+    typedef struct InError InError;
     InError* inErrorGet();
 
-    struct InPuppet;
-    struct InCamera;
-    struct InRenderable;
+    typedef struct InPuppet InPuppet;
+    typedef struct InCamera InCamera;
+    typedef struct InRenderable InRenderable;
 
     // Inochi2D runtime functionality
     void inInit(double (*timingFunc)());


### PR DESCRIPTION
These 2 patches make `inochi2d.h` compile, and allows the library to be linked using C and C++.

The first patch fixes a syntax issue and creates type definitions so that the C compiler doesn't complain, and the second disables name mangling when using a C++ compiler.

I used the following testing setup:

```console
 $ cat > test.c << EOF
> #include "inochi2d.h"
>
> int main() {
>     inCameraGetCurrent(); // Random function to make sure linking works
> }
> EOF
 $ cp test.c test.cpp
 $ clang test.c out/libinochi2d-c.so
 $ clang++ test.cpp out/libinochi2d-c.so
 $ # No errors were reported.
```

This fixes the issues I described in #3.